### PR TITLE
package.json version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "color-convert": "^1.9.3",
     "debug": "^3.2.6",
     "mqtt": "^2.18.8",
-    "tuyapi": "github:codetheweb/tuyapi"
+    "tuyapi": "^3.2.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I kept running into problems with the version of tuyapi set to the original value and kept exiting with exit code 99.  When I updated the version to the latest version in github for tuyapi all issues were resolved.